### PR TITLE
adding a citation as well as a LICENSE file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+message: "If you use this dataset, please cite it as below."
+authors:
+- family-names: "Shadabfar"
+  given-names: "Hossein"
+  orcid: ""
+- family-names: "Dehghan"
+  given-names: "Motahareh"
+  orcid: ""
+- family-names: "Sadeghian"
+  given-names: "Babak"
+  orcid: ""
+title: "DSRL-APT-2023: A New Synthetic Dataset For Advanced Persistent Threats"
+version: 1.0.0
+date-released: TBC
+url: "https://github.com/shadab75/DSRL-APT-2023"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Hossein Shadabfar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Proposed to add the following files:
- CITATION.cff: It's always a good idea to guide consumers of a repo about how they can cite the repo - it'd also systematically increase the visibility of the repo.
- LICENSE: Having a licence would make it clear for the community how they can use the repo (in this case the dataset) - of course you can always change it according to your policies for the repo.
